### PR TITLE
_get_info_field introduced instead fo dict fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.7] - 2025-07-07
+
+### Changed
+- Refactored `PincodeData` methods (`get_state`, `get_district`, `get_taluk`, `get_offices`) to use a common helper method `_get_info_field` for improved code reusability and maintainability.
+- Ensured type hint compatibility with `mypy` by explicitly casting return types where necessary.
+
+### Technical Improvements
+- Implemented `lru_cache` for `_get_default_instance` to ensure `PincodeData` is a singleton and loaded only once, optimizing performance for repeated calls to convenience functions.
+- Removed redundant global variable `_default_pincode_data` for a cleaner and more minimal codebase, leveraging `lru_cache` for instance management.
+- Removed duplicate import statements (`os`, `re`).
+
 ## [0.1.6] - 2025-01-04
 
 ### Added
 - **Complete rewrite with modern Python practices**
 - Repo links changed
 - Author added
-
-## [0.1.6] - 2025-01-04
 
 ### Added
 - **Complete rewrite with modern Python practices**

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A modern Python library for Indian pincode lookup and geographical information.
 
 ## Features
 
+- **Optimized Performance**: Utilizes `lru_cache` for efficient singleton instance management, ensuring faster lookups.
+- **Refactored Codebase**: Improved internal code structure with helper methods for better maintainability and reduced duplication.
 - **Comprehensive Pincode Database**: Complete Indian pincode data with office information
 - **Multiple Lookup Methods**: Search by pincode, state, district, or office name
 - **Modern Python API**: Clean, type-hinted interface with both functional and object-oriented approaches
@@ -337,13 +339,19 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ## Changelog
 
+### v0.1.7
+- **Performance Enhancement**: Implemented `lru_cache` for `_get_default_instance` to ensure `PincodeData` is a singleton and loaded only once, optimizing performance for repeated calls to convenience functions.
+- **Code Refactoring**: Refactored `PincodeData` methods (`get_state`, `get_district`, `get_taluk`, `get_offices`) to use a common helper method `_get_info_field` for improved code reusability and maintainability.
+- **Code Clean-up**: Removed redundant global variable `_default_pincode_data` and duplicate import statements (`os`, `re`).
+- **Type Hinting**: Ensured type hint compatibility with `mypy` by explicitly casting return types where necessary.
+
 ### v0.1.6
 - **Complete rewrite with modern Python practices**
 - Added comprehensive API with both functional and OOP interfaces
 - Added full CLI tool with extensive options
 - Added comprehensive test suite with high coverage
 - Added type hints throughout the codebase
-- Added proper exception handling cwith custom exceptions
+- Added proper exception handling with custom exceptions
 - Added search functionality by state, district, and office name
 - Added statistics and data exploration features
 - Added examples and comprehensive documentation

--- a/tests/test_pypinindia.py
+++ b/tests/test_pypinindia.py
@@ -248,6 +248,20 @@ class TestConvenienceFunctions:
         result = get_pincode_info("110001")
         assert result == mock_info
         mock_instance.get_pincode_info.assert_called_once_with("110001")
+    
+    @patch('pinin.core.PincodeData')
+    def test_get_default_instance_singleton(self, MockPincodeData):
+        """Test that _get_default_instance returns a singleton."""
+        from pinin.core import _get_default_instance
+        
+        # Clear the cache to ensure a fresh instance is created
+        _get_default_instance.cache_clear()
+        
+        instance1 = _get_default_instance()
+        instance2 = _get_default_instance()
+        
+        assert instance1 is instance2
+        MockPincodeData.assert_called_once()
 
 
 class TestStatistics:


### PR DESCRIPTION
### Changed
- Refactored `PincodeData` methods (`get_state`, `get_district`, `get_taluk`, `get_offices`) to use a common helper method `_get_info_field` for improved code reusability and maintainability.
- Ensured type hint compatibility with `mypy` by explicitly casting return types where necessary.

### Technical Improvements
- Implemented `lru_cache` for `_get_default_instance` to ensure `PincodeData` is a singleton and loaded only once, optimizing performance for repeated calls to convenience functions.
- Removed redundant global variable `_default_pincode_data` for a cleaner and more minimal codebase, leveraging `lru_cache` for instance management.
- Removed duplicate import statements (`os`, `re`).