### PR TITLE
test search by district state mismatch

### DIFF
--- a/tests/test_pypinindia.py
+++ b/tests/test_pypinindia.py
@@ -256,7 +256,12 @@ class TestSearchFunctionality:
         """Test searching pincodes by district with state filter."""
         result = mock_search_data.search_by_district("Mumbai", "MAHARASHTRA")
         assert len(result) == 2
-    
+
+    def test_search_by_district_state_mismatch(self,mock_search_data):
+        """District exists, but not in the specified state."""
+        result = mock_search_data.search_by_district("Mumbai", "DELHI")
+        assert result == []
+
     def test_get_states(self, mock_search_data):
         """Test getting all states."""
         result = mock_search_data.get_states()


### PR DESCRIPTION
Tests search_by_district with a valid district but wrong state

🧪 Input: "Mumbai" (district), "DELHI" (wrong state)

🎯 Expected: [] (no results)

📌 Ensures both district and state filters are applied correctly

❌ Prevents false positives from partial matches

