### PR TITLE
Add method to fetch unique post offices by state in core.py

### DIFF
--- a/pinin/core.py
+++ b/pinin/core.py
@@ -86,7 +86,6 @@ class PincodeData:
             ]
         
         return sorted(filtered_data['taluk'].dropna().unique().tolist()) if not filtered_data.empty else []
-
     
     def get_unique_offices_by_state(self, state_name: str) -> List[str]:
         """


### PR DESCRIPTION
✨ Updates:

    Added two new methods for state-wise postal data queries:
        get_unique_offices_by_state(state_name) — Returns unique post office names in a given state.
        get_office_types_by_state(state_name) — Returns unique post office types in a given state.

    Refactored overlapping function names to avoid redefinition:
        Ensured unique method names (get_unique_offices_by_state and get_office_types_by_state) for clarity.

    Fixed mypy type-checking error:
        Corrected function return type hints to avoid Any return warnings in get_statistics().

✅ Benefits:

    Cleaner, safer, and mypy-compliant code.
    State-wise postal queries made easier for developers.
    No function name clashes or duplicate definitions.
    