### PR TITLE
Added get_postoffice_summary helper function and SummaryError Exception

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,29 @@
+#added a method get_postoffice_summary to returns a summarized count of post offices by their type and delivery status for a given pincode.
+
+
+from pinin import get_postoffice_summary
+
+def main():
+    print("\n2. Post Office Summary")
+    print("-" * 30)
+    summary = get_postoffice_summary("110001")
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# from pinin.exceptions import SummaryError
+
+# def test_summary_error():
+#     print("\n3. Summary Error Test")
+#     print("-" * 30)
+#     try:
+#         # Use an invalid pincode that causes summary error (simulate it manually if needed)
+#         raise SummaryError("123456")
+#     except SummaryError as e:
+#         print(f"Caught SummaryError: {e}")
+# if __name__ == "__main__":
+#     # main()
+#     test_summary_error()

--- a/pinin/__init__.py
+++ b/pinin/__init__.py
@@ -32,12 +32,14 @@ from .core import (
     search_by_district,
     get_states,
     get_districts,
+    get_postoffice_summary,
 )
 from .exceptions import (
     PininError,
     InvalidPincodeError,
     DataNotFoundError,
     DataLoadError,
+    SummaryError
 )
 
 __version__ = "0.1.7"
@@ -59,4 +61,6 @@ __all__ = [
     "InvalidPincodeError",
     "DataNotFoundError",
     "DataLoadError",
+    "get_postoffice_summary",
+    "SummaryError"
 ]

--- a/pinin/core.py
+++ b/pinin/core.py
@@ -447,8 +447,40 @@ class PincodeData:
             'unique_offices': self.data['officename'].nunique() if not self.data.empty else 0,
         }
     
-   
-    @staticmethod
+
+
+        # ----------------------------------------------------------
+    # NEW: Summary helper method for a given pincode
+    #
+    # This method provides a quick summary of:
+    # - Total number of post offices under a pincode
+    # - Distribution of office types (e.g., H.O, S.O, B.O)
+    # - Distribution of delivery statuses (e.g., Delivery, Non-Delivery)
+    #
+    # Useful for analytics, visualizations, and high-level insights.
+    # ----------------------------------------------------------
+
+
+    def get_postoffice_summary(self, pincode: Union[str, int]) -> Dict[str, Any]:
+        if self.data is None:
+            raise DataLoadError("Data not loaded")
+
+        pincode_str = self._validate_pincode(pincode)
+        filtered_data = self._get_matching_rows(pincode_str)
+
+        if filtered_data.empty:
+            raise DataNotFoundError(pincode_str)
+
+        total = len(filtered_data)
+        types = filtered_data['officetype'].value_counts().to_dict()
+        delivery = filtered_data['Deliverystatus'].value_counts().to_dict()
+
+        return {
+            "total": total,
+            "types": types,
+            "delivery_statuses": delivery
+        }
+    
     def _normalize(text: str) -> str:
         """
         Normalize text by:
@@ -483,6 +515,8 @@ class PincodeData:
         ]
         
         return result
+    
+    
 
     def suggest_districts(self, query: str, state_name: Optional[str] = None, n: int = 5, cutoff: float = 0.6) -> List[str]:
         districts = self.get_districts(state_name)
@@ -516,6 +550,7 @@ class PincodeData:
 def _get_default_instance() -> PincodeData:
     """Get or create the default PincodeData instance."""
     return PincodeData()
+    
 
 
 # Convenience functions
@@ -632,3 +667,18 @@ def get_districts(state_name: Optional[str] = None) -> List[str]:
         List of district names
     """
     return _get_default_instance().get_districts(state_name)
+
+
+
+
+def get_postoffice_summary(pincode: Union[str, int]) -> Dict[str, Any]:
+    # """
+    # Convenience function to get post office summary for a pincode.
+
+    # Args:
+    #     pincode: The pincode to summarize
+
+    # Returns:
+    #     Dictionary with summary statistics
+    # """
+    return _get_default_instance().get_postoffice_summary(pincode)

--- a/pinin/exceptions.py
+++ b/pinin/exceptions.py
@@ -52,3 +52,21 @@ class DataLoadError(PininError):
             full_message += f"\nOriginal Exception: {type(original_exception).__name__}: {original_exception}"
         
         super().__init__(full_message)
+    
+
+    
+class SummaryError(PininError):
+    """Raised when a summary operation fails or is unsupported."""
+
+    def __init__(self, pincode: Optional[str] = None, message: Optional[str] = None):
+        self.pincode = pincode
+
+        if message:
+            full_message = message
+        elif pincode:
+            full_message = f"Summary unavailable for pincode: '{pincode}'"
+        else:
+            full_message = "Summary operation failed."
+
+        super().__init__(full_message)
+


### PR DESCRIPTION
### 🔧 Summary

This PR contributes two enhancements:

1. **`get_postoffice_summary(pincode)`**  
   - A new helper in `core.py` that provides summary stats:
     - Total post offices
     - Office type counts (H.O, S.O, B.O)
     - Delivery status counts

2. **`SummaryError` Exception in `exceptions.py`**  
   - Custom error class to support future summary/reporting use cases.
   - Currently not integrated into the post office summary, but available for analytics functions later.

### ✅ Also included
- New `example.py` demonstrating usage and testing error cases.
- Clean separation of concerns (helper logic + exception logic).

Looking forward to feedback and suggestions!
<img width="767" height="497" alt="op" src="https://github.com/user-attachments/assets/fedcab50-2715-48fe-875c-6ecb1c43dc13" />
